### PR TITLE
chore(soldeer): bump [package].version to 0.1.1 for next-version release lifecycle

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-sol-binmaskflag"
-version = "0.1.0"
+version = "0.1.1"
 
 [profile.default]
 


### PR DESCRIPTION
Closes #17

## What

Bump `foundry.toml` `[package].version` from `0.1.0` to `0.1.1` — the next, in-development (unpublished) Soldeer revision.

The shared `rainix-autopublish` reusable (pinned `@main`) moved from auto-bump to the **next-version release lifecycle** (rainlanguage/rainix#264). Under it, `[package].version` must be **strictly ahead** of the latest published revision; when they are equal the publish gate fails loud on the next Solidity-content merge:

> `foundry.toml [package].version (0.1.0) is not ahead of the published revision (0.1.0) …`

This one-time bump moves the repo onto the new lifecycle; thereafter each publish self-bumps.

## Why 0.1.1

- `foundry.toml [package].version` = `0.1.0`
- Latest published `rain-sol-binmaskflag` Soldeer revision = `0.1.0` (equal → gate fails)
- Next unpublished patch = `0.1.1` (strictly ahead ✓)

Pure-library repo — no version-keyed generated artifacts (`src/generated` absent), so no `soldeer-generate-cmd:` wiring is required (per the issue's guidance).

## QA evidence

Per QA-GUIDE.md §8. This is a **config-only** change to `foundry.toml [package].version`; there is no Solidity/behavioral surface introduced or altered. `[package].version` is Soldeer **publish metadata** — it is not read by `solc`, so compiled bytecode and the existing test suite are independent of it. No function, branch, or assertion exists to mutation-test.

- **Correctness oracle (independent):** the autopublish invariant — in-dev version strictly greater than the latest published revision. The pre-change value `0.1.0` is *equal* to the published revision `0.1.0` (would fail the gate); `0.1.1 > 0.1.0` satisfies strict-ahead.
- **No weakening:** no test or assertion is added, removed, or loosened; the version string gates no test.
- **Scope:** single line, single file (`foundry.toml`).
- **Verification:** authoritative check is CI — the `rainix-sol` build/test job (bytecode/tests unaffected by the metadata string) plus the `rainix-autopublish` version-gate, which now passes with the in-dev version strictly ahead.

Ref: rainlanguage/rainix#264

Co-Authored-By: Claude <noreply@anthropic.com>
